### PR TITLE
Support a server-first mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:experimental
 
-ARG RUST_IMAGE=rust:1.45.2
+ARG RUST_IMAGE=rust:1.49.0
 ARG RUNTIME_IMAGE=debian:buster-20200803-slim
 
 FROM $RUST_IMAGE as build
 WORKDIR /usr/src/tcp-echo
 COPY . .
 RUN --mount=type=cache,target=target \
-    --mount=type=cache,from=rust:1.45.2,source=/usr/local/cargo,target=/usr/local/cargo \
+    --mount=type=cache,from=rust:1.49.0,source=/usr/local/cargo,target=/usr/local/cargo \
     cargo build --locked --release &&  mv target/release/tcp-echo /tmp
 
 FROM $RUNTIME_IMAGE as runtime

--- a/templates/client.yml
+++ b/templates/client.yml
@@ -29,6 +29,9 @@ spec:
       containers:
         - name: main
           image: {{ .Values.image }}
+          env:
+            - name: RUST_LOG
+              value: debug
           args:
             - client
             - --concurrency={{.Values.client.concurrency | default 1}}

--- a/templates/client.yml
+++ b/templates/client.yml
@@ -5,13 +5,13 @@ metadata:
     app: tcp-echo
     role: client
   name: client
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
       app: tcp-echo
       role: client
-  replicas: {{int .Values.client.replicas}}
+  replicas: {{ int .Values.client.replicas }}
   template:
     metadata:
       labels:
@@ -19,20 +19,21 @@ spec:
         role: client
       annotations:
         linkerd.io/inject: {{.Values.client.linkerdInject | default false | ternary "enabled" "disabled" }}
-{{- if .Values.linkerd.proxyImage}}
-        config.linkerd.io/proxy-image: {{.Values.linkerd.proxyImage}}
-{{- end}}
-{{- if .Values.linkerd.proxyVersion}}
-        config.linkerd.io/proxy-version: {{.Values.linkerd.proxyVersion}}
-{{- end}}
+        {{- if .Values.linkerd.proxyImage }}
+        config.linkerd.io/proxy-image: {{ .Values.linkerd.proxyImage }}
+        {{- end }}
+        {{- if .Values.linkerd.proxyVersion }}
+        config.linkerd.io/proxy-version: {{ .Values.linkerd.proxyVersion }}
+        {{- end }}
     spec:
       containers:
         - name: main
-          image: ghcr.io/olix0r/tcp-echo:v8
+          image: {{ .Values.image }}
           args:
             - client
             - --concurrency={{.Values.client.concurrency | default 1}}
-{{- range $i, $e := until (.Values.server.services | int) }}
+            - --reverse={{ .Values.reverse }}
+            {{- range $i, $e := until (.Values.server.services | int) }}
             - {{printf "tcp://echo-%03d:4444" $i}}
-{{- end}}
+            {{- end }}
 

--- a/templates/server.yml
+++ b/templates/server.yml
@@ -61,6 +61,9 @@ spec:
       containers:
         - name: main
           image: {{ $image }}
+          env:
+            - name: RUST_LOG
+              value: debug
           args:
             - server
             - "4444"

--- a/templates/server.yml
+++ b/templates/server.yml
@@ -1,16 +1,18 @@
-{{- $ns := .Release.Namespace}}
-{{- $replicas := int .Values.server.replicas}}
-{{- $linkerd := .Values.linkerd}}
-{{- $inject := .Values.server.linkerdInject}}
-{{- range $i, $e := until (.Values.server.services | int) }}
+{{- $ns := .Release.Namespace }}
+{{- $image := .Values.image }}
+{{- $replicas := int .Values.server.replicas }}
+{{- $linkerd := .Values.linkerd }}
+{{- $inject := .Values.server.linkerdInject }}
+{{- $reverse := .Values.reverse }}
+{{- range $i, $e := until (int .Values.server.services) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: tcp-echo
-  name: echo-{{printf "%03d" $i}}
-  namespace: {{$ns}}
+  name: echo-{{ printf "%03d" $i }}
+  namespace: {{ $ns }}
 spec:
   selector:
     app: tcp-echo
@@ -27,37 +29,40 @@ metadata:
   labels:
     app: tcp-echo
     role: server
-    instance: {{quote $i}}
-  name: server-{{printf "%03d" $i}}
-  namespace: {{$ns}}
+    instance: {{ quote $i }}
+  name: server-{{ printf "%03d" $i }}
+  namespace: {{ $ns }}
 spec:
   selector:
     matchLabels:
       app: tcp-echo
       role: server
       instance: {{quote $i}}
-  replicas: {{$replicas}}
+  replicas: {{ $replicas }}
   template:
     metadata:
       labels:
         app: tcp-echo
         role: server
-        instance: {{quote $i}}
+        instance: {{ quote $i }}
       annotations:
-        linkerd.io/inject: {{$inject | default false | ternary "enabled" "disabled" }}
-{{- if $linkerd.proxyImage}}
-        config.linkerd.io/proxy-image: {{$linkerd.proxyImage}}
-{{- end}}
-{{- if $linkerd.proxyVersion}}
-        config.linkerd.io/proxy-version: {{$linkerd.proxyVersion}}
-{{- end}}
+        linkerd.io/inject: {{ $inject | default false | ternary "enabled" "disabled" }}
+        {{- if $linkerd.proxyImage }}
+        config.linkerd.io/proxy-image: {{ $linkerd.proxyImage }}
+        {{- end }}
+        {{- if $linkerd.proxyVersion }}
+        config.linkerd.io/proxy-version: {{ $linkerd.proxyVersion }}
+        {{- end }}
     spec:
       containers:
         - name: main
-          image: ghcr.io/olix0r/tcp-echo:v8
-          args: ["server", "4444"]
+          image: {{ $image }}
+          args:
+            - server
+            - "4444"
+            - --reverse={{ $reverse }}
           ports:
             - containerPort: 4444
               protocol: TCP
               name: echo
-{{- end -}}
+{{- end }}

--- a/templates/server.yml
+++ b/templates/server.yml
@@ -3,6 +3,7 @@
 {{- $replicas := int .Values.server.replicas }}
 {{- $linkerd := .Values.linkerd }}
 {{- $inject := .Values.server.linkerdInject }}
+{{- $opaque := .Values.server.opaque }}
 {{- $reverse := .Values.reverse }}
 {{- range $i, $e := until (int .Values.server.services) }}
 ---
@@ -52,6 +53,9 @@ spec:
         {{- end }}
         {{- if $linkerd.proxyVersion }}
         config.linkerd.io/proxy-version: {{ $linkerd.proxyVersion }}
+        {{- end }}
+        {{- if or $reverse $opaque }}
+        config.linkerd.io/opaque-ports: "4444"
         {{- end }}
     spec:
       containers:

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,7 @@ server:
   services: 1
   replicas: 1
   linkerdInject: true
+  opaque: false
 
 linkerd: {}
   #proxyImage: ...

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,7 @@
+image: ghcr.io/olix0r/tcp-echo:v8
+
+reverse: false
+
 client:
   replicas: 1
   linkerdInject: true

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-image: ghcr.io/olix0r/tcp-echo:v8
+image: ghcr.io/olix0r/tcp-echo:v9
 
 reverse: false
 


### PR DESCRIPTION
This change adds a `--reverse` flag to the client and server.  When
set, the server sends the message and the client echoes it.

The Helm chart has been updated to support this as well. When set, the
server is annotated with a opaque-ports annotation so that the proxy
skips protocol detection.