### PR TITLE
Ignore files when building Helm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+*.tgz

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when building packages.
+.dockerignore
+.git/
+.github/
+.gitignore
+Dockerfile
+LICENSE
+rust-toolchain
+src/
+target/
+*.lock
+*.tgz
+*.toml


### PR DESCRIPTION
This ignores certain files and directories when building the Helm package.
Without ignoring, `helm package .` results in too large of a package and `helm
install` fails:

```
❯ helm package .
Successfully packaged chart and saved it to: /home/kevin/Projects/olix0r/tcp-echo/tcp-echo-0.1.0.tgz

❯ helm install tcp-echo tcp-echo-0.1.0.tgz
Error: create: failed to create: Request entity too large: limit is 3145728
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>